### PR TITLE
Reset compressed layout hierarchy state after dump

### DIFF
--- a/app/src/androidTest/java/com/github/uiautomator/stub/AutomatorServiceImpl.java
+++ b/app/src/androidTest/java/com/github/uiautomator/stub/AutomatorServiceImpl.java
@@ -182,6 +182,8 @@ public class AutomatorServiceImpl implements AutomatorService {
             e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();
+        } finally {
+            device.setCompressedLayoutHeirarchy(false);
         }
 
         return null;


### PR DESCRIPTION
If the d.dump(compressed=True) is called all subsequent calls will
only show a compressed view. Force the compressed layout heirarchy
state back to the default of false to make subsequent calls work
correctly.

https://github.com/xiaocong/uiautomator/issues/156