### PR TITLE
Added clearHierarachyCache method

### DIFF
--- a/app/src/androidTest/java/com/github/uiautomator/stub/AutomatorService.java
+++ b/app/src/androidTest/java/com/github/uiautomator/stub/AutomatorService.java
@@ -937,4 +937,10 @@ public interface AutomatorService {
      */
     @JsonRpcErrors({@JsonRpcError(exception=NotImplementedException.class, code=ERROR_CODE_BASE)})
     String toast(String switchStatus) throws NotImplementedException;
+
+    /**
+     * Method used to clear hierarachy in case of an update not occurring
+     */
+    @JsonRpcErrors({@JsonRpcError(exception=UiAutomator2Exception.class, code=ERROR_CODE_BASE)})
+    void clearHierarchyCache();
 }

--- a/app/src/androidTest/java/com/github/uiautomator/stub/AutomatorServiceImpl.java
+++ b/app/src/androidTest/java/com/github/uiautomator/stub/AutomatorServiceImpl.java
@@ -1641,4 +1641,14 @@ public class AutomatorServiceImpl implements AutomatorService {
         }
         return null;
     }
+
+    @Override
+    public void clearHierarchyCache() {
+        try {
+            ReflectionUtils.clearAccessibilityCache();
+        }catch (Exception e) {
+            e.printStackTrace();
+            throw new UiAutomator2Exception(e);
+        }
+    }
 }


### PR DESCRIPTION
I've found that the accessibility view cache gets stale sometimes when changing fragments on screen. To solve this you can clear the cache.  I've added a method to do just this.